### PR TITLE
field normalization

### DIFF
--- a/Windows/processlog.py
+++ b/Windows/processlog.py
@@ -38,8 +38,8 @@ def log_existing_processes(logger):
           parent_name = parent.name()
 
       log_message(logger, f"timestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} | "
-        f"event: existing process | "
-        f"pid: {pid} | name: {proc_name} | hostname: {hostname} | ppid: {parent_pid} | parent: {parent_name} | username: {user} | sid: {sid}")
+        f"hostname: {hostname} | username: {user} | event: existing process | "
+        f"pid: {pid} | name: {proc_name} | ppid: {parent_pid} | parent: {parent_name} | sid: {sid}")
     except (psutil.NoSuchProcess, psutil.AccessDenied):
       continue  # Ignore processes that vanish before logging
 
@@ -76,8 +76,8 @@ def monitor_process_events(log_directory, ready_directory, interval=1):
             parent_name: str = parent.name()
 
         log_message(logger, f"timestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} | "
-          f"event: process created | "
-          f"pid: {pid} | name: {proc_name} | hostname: {hostname} | ppid: {parent_pid} | parent: {parent_name} | username: {user} | sid: {sid}"
+          f"hostname: {hostname} | username: {user} | event: process created | "
+          f"pid: {pid} | name: {proc_name} | ppid: {parent_pid} | parent: {parent_name} | sid: {sid}"
         )
       except (psutil.NoSuchProcess, psutil.AccessDenied):
         continue
@@ -101,8 +101,9 @@ def monitor_process_events(log_directory, ready_directory, interval=1):
             f"pid: {pid} | name: {proc_name} | hostname: {hostname} | ppid: {parent_pid} | parent: {parent_name} | username: {user} | sid: {sid}")
       except (psutil.NoSuchProcess, psutil.AccessDenied):
         log_message(logger, f"timestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} | "
-          f"event: process terminated | "
-          f"pid: {pid} | name: | hostname: | ppid: | parent: | username: | sid: {sid}")
+          f"hostname: {hostname} | username: {user} | event: process terminated | "
+          f"pid: {pid} | name: {proc_name} | ppid: {parent_pid} | parent: {parent_name} | sid: {sid}")
+          #f"pid: {pid} | name: | hostname: | ppid: | parent: | username: | sid: {sid}")
 
     # Print the current running total of log lines every 10 seconds
     if int(time.time()) % 10 == 0:

--- a/Windows/softwareinventorylog.py
+++ b/Windows/softwareinventorylog.py
@@ -44,8 +44,9 @@ def log_installed_software(log_directory, ready_directory):
   for name, version in get_installed_software():
       log_entry = (
         f"timestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} | "
-        f"hostname: {hostname} | sid: {sid} | instanceid: {instance_id} | "
-        f"program: {name} | version: {version}"
+        f"hostname: {hostname} | "
+        f"program: {name} | version: {version} | "
+        f"instanceid: {instance_id} | sid: {sid}"
       )
       logger.info(log_entry)
       log_line_count += 1

--- a/Windows/windowsserviceslog.py
+++ b/Windows/windowsserviceslog.py
@@ -26,11 +26,11 @@ def log_services(log_directory, ready_directory):
     if info['status'] == 'running': 
       service_info = (
         f"timestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} | "
-        f"hostname: {hostname} | sid: {computer_sid} | "
-        f"servicename:{info['name']!r} | displayname:{info['display_name']!r} | "
+        f"hostname: {hostname} | username: {info['username']} | "
+        f"pid: {info['pid']} | servicename:{info['name']!r} | displayname:{info['display_name']!r} | "
         f"status: {info['status']} | start: {info['start_type']} | "
-        f"username: {info['username']} | pid: {info['pid']} | "
-        f"executable: {info['binpath']}"
+        f"executable: {info['binpath']} | "
+        f"sid: {computer_sid} | "
       )
       logger.info(service_info)
       log_line_count += 1


### PR DESCRIPTION
all events have these fields in common:

timestamp, hostname, username, event name

arranged these fields in this order for standardizing the field layout among logs for readability.  moved sid to the end b/c that field is mostly repeated, takes a lot of horizontal space, and not one of the most frequently read fields. 

added some parent info and username fields to process termination events, these seem to be reliable.

@anidev95 : does a field order change need to be changed to match in the storedata script for database insertion?